### PR TITLE
Adding Streamlit setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dmypy.json
 
 # Environment files
 .envrc
+*.DS_Store

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 79
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party =fastapi,pydantic,streamlit
+known_third_party =fastapi,pydantic,streamlit,validators

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 79
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party =fastapi,pydantic
+known_third_party =fastapi,pydantic,streamlit

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-03-01, Travis Craft and Victor Calderon
+Copyright (c) 2023 Victor Calderon and Travis Craft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,8 +9,8 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/Makefile
+++ b/Makefile
@@ -380,6 +380,10 @@ add-licenses:
 		-f ./LICENSE.rst  \
 		./src/**/*.py
 
+## Open up all web endpoints
+all-web: api-web streamlit-app-web
+	@	echo "All web endpoints opened!"
+
 ###############################################################################
 # Self Documenting Commands                                                   #
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -327,12 +327,20 @@ api-web:
 	@	python -m webbrowser "$(APP_WEBSERVER_URL)/docs"
 
 ###############################################################################
-# Unit Tests   					                                              #
+# Unit Tests and Code checking                                                #
 ###############################################################################
 
 ## Run all Python unit tests with verbose output and logs
 test:
 	python -m pytest -v -s
+
+## Add licenses to Python files
+add-licenses:
+	@	docker run -it \
+		-v ${PWD}:/src \
+		ghcr.io/google/addlicense \
+		-f ./LICENSE.rst  \
+		./src/**/*.py
 
 ###############################################################################
 # Self Documenting Commands                                                   #

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ One can see all of the available options by:
 
     Available rules:
 
+    add-licenses              Add licenses to Python files
     all-start                 Starts both the API service and the local development service
     all-stop                  Stops both the API service and the local development service
+    all-web                   Open up all web endpoints
     api-build                 Build API image
     api-start                 Start API image container
     api-stop                  Stop API image container
@@ -83,6 +85,11 @@ One can see all of the available options by:
     requirements              Install Python dependencies into the Python environment
     show-params               Show the set of input parameters
     sort-requirements         Sort the project packages requirements file
+    streamlit-app-build       Build Streamlit App image
+    streamlit-app-start       Start Streamlit App image container
+    streamlit-app-stop        Stop Streamlit App image container
+    streamlit-app-web         Open Streamlit App in web browser
+    test                      Run all Python unit tests with verbose output and logs
 ```
 
 > **NOTE**: If you're using `Windows`, you may have to copy and modify to some

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -45,3 +45,28 @@ services:
         "--reload-dir",
         "/opt/ml"
       ]
+  #
+  # --- Service for running the Streamlit application locally
+  streamlit:
+    # Building the local image
+    build:
+      context: ../
+      dockerfile: ./docker/image_analyzer.Dockerfile
+    # Running the local image
+    image: "ai-image-analyzer-streamlit"
+    container_name: "ai-image-analyzer-streamlit"
+    environment:
+      STREAMLIT_SERVER_PORT: ${STREAMLIT_SERVER_PORT}
+    volumes:
+      - ..:/opt/streamlit
+    ports:
+      - ${STREAMLIT_SERVER_PORT:-8501}:${STREAMLIT_SERVER_PORT:-8501}
+    working_dir: /opt/streamlit
+    command:
+      [
+        "streamlit",
+        "run",
+        "src/streamlit_app/app.py",
+        "--server.port",
+        "8501"
+      ]

--- a/docker/image_analyzer.Dockerfile
+++ b/docker/image_analyzer.Dockerfile
@@ -39,6 +39,7 @@ COPY ${REQUIREMENTS_FILE} "${HOME_DIR}/${REQUIREMENTS_FILE}"
 # ---------------------- EXPOSING PORTS FOR APP -------------------------------
 
 EXPOSE 80
+EXPOSE 8501
 
 # --------------------- INSTALLING EXTRA PACKAGES -----------------------------
 # --- Updating packages and installing packages at the system-level

--- a/docker/image_analyzer.Dockerfile
+++ b/docker/image_analyzer.Dockerfile
@@ -84,6 +84,13 @@ RUN apt-get update -y && \
 RUN pip install --upgrade pip && \
     python -m pip install -r "${HOME_DIR}/${REQUIREMENTS_FILE}"
 
+# Temporary fix for PyTube's error: https://github.com/pytube/pytube/issues/1498
+ENV CIPHER_FILEPATH="/usr/local/lib/python3.9/site-packages/pytube/cipher.py"
+RUN sed -i 's/findall(transform_plan_raw)/findall(js)/g' \
+    ${CIPHER_FILEPATH} && \
+    sed  -i 's/transform_plan_raw/#transform_plan_raw/g' \
+    ${CIPHER_FILEPATH}
+
 # ----------------------------- PYTHON-SPECIFIC -------------------------------
 
 # Set some environment variables. PYTHONUNBUFFERED keeps Python from

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.92.0
 pydantic==1.10.5
+streamlit==1.20.0
 uvicorn==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 fastapi==0.92.0
 pydantic==1.10.5
+pytube==12.1.2
 streamlit==1.20.0
 uvicorn==0.20.0
+validators==0.20.0

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,21 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/src/api/index.py
+++ b/src/api/index.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from fastapi import FastAPI
 
 from src.classes.analyze_video_response import AnalyzeVideoResponse

--- a/src/classes/__init__.py
+++ b/src/classes/__init__.py
@@ -1,0 +1,21 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/src/classes/analysis_results.py
+++ b/src/classes/analysis_results.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from pydantic import BaseModel
 
 

--- a/src/classes/analyze_video_response.py
+++ b/src/classes/analyze_video_response.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from pydantic import BaseModel
 
 from src.classes.analysis_results import AnalysisResults

--- a/src/classes/video_data.py
+++ b/src/classes/video_data.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from typing import Any
 
 from pydantic import BaseModel

--- a/src/classes/video_data.py
+++ b/src/classes/video_data.py
@@ -20,11 +20,58 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Any
+import logging
 
+import validators
 from pydantic import BaseModel
 
+__author__ = ["Victor Calderon and Travis Craft"]
+__maintainer__ = ["Victor Calderon and Travis Craft"]
+__all__ = ["VideoDataDAO"]
 
-class VideoData(BaseModel):
-    raw_video: Any
-    url: str
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger.setLevel(logging.INFO)
+
+
+class VideoDataDAO(BaseModel):
+    """
+    Class object for interacting with an input video
+    """
+
+    def __init__(self, url: str):
+        """
+        Class object that interacts with video files.
+        """
+        # -- Defining class attributes
+        self.url = url
+        # Validating URL
+        self._validate_video_url()
+
+    def _validate_video_url(self):
+        """
+        Method for validating the input URL. This method checks
+        whether or not the URL is a valid Youtube URL.
+
+        Raises
+        ----------
+        ValueError : Exception
+            This error gets raised whenever the URL is not valid.
+        """
+        # Validating the input URL
+        if not validators.url(self.url):
+            msg = f">>> URL `{self.url}` is not valid!"
+            logger.error(msg)
+            raise ValueError(msg)
+
+        return
+
+    def download_stream(self):
+        """
+        Method for downloading the stream from the input video.
+
+        Returns
+        ------------
+        """
+
+        return

--- a/src/classes/video_data.py
+++ b/src/classes/video_data.py
@@ -23,7 +23,6 @@
 import logging
 
 import validators
-from pydantic import BaseModel
 
 __author__ = ["Victor Calderon and Travis Craft"]
 __maintainer__ = ["Victor Calderon and Travis Craft"]
@@ -34,7 +33,7 @@ logging.basicConfig(level=logging.INFO)
 logger.setLevel(logging.INFO)
 
 
-class VideoDataDAO(BaseModel):
+class VideoDataDAO(object):
     """
     Class object for interacting with an input video
     """

--- a/src/classes/video_data.py
+++ b/src/classes/video_data.py
@@ -26,14 +26,14 @@ import validators
 
 __author__ = ["Victor Calderon and Travis Craft"]
 __maintainer__ = ["Victor Calderon and Travis Craft"]
-__all__ = ["VideoDataDAO"]
+__all__ = ["VideoData"]
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 logger.setLevel(logging.INFO)
 
 
-class VideoDataDAO(object):
+class VideoData(object):
     """
     Class object for interacting with an input video
     """
@@ -62,8 +62,6 @@ class VideoDataDAO(object):
             msg = f">>> URL `{self.url}` is not valid!"
             logger.error(msg)
             raise ValueError(msg)
-
-        return
 
     def download_stream(self):
         """

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,21 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/src/services/image_analysis_service.py
+++ b/src/services/image_analysis_service.py
@@ -21,9 +21,9 @@
 # SOFTWARE.
 
 from src.classes.analysis_results import AnalysisResults
-from src.classes.video_data import VideoData
+from src.classes.video_data import VideoDataDAO
 
 
-def run_image_analysis(video_data: VideoData) -> AnalysisResults:
+def run_image_analysis(video_data: VideoDataDAO) -> AnalysisResults:
     print("Running image analysis...")
     return AnalysisResults()

--- a/src/services/image_analysis_service.py
+++ b/src/services/image_analysis_service.py
@@ -21,9 +21,9 @@
 # SOFTWARE.
 
 from src.classes.analysis_results import AnalysisResults
-from src.classes.video_data import VideoDataDAO
+from src.classes.video_data import VideoData
 
 
-def run_image_analysis(video_data: VideoDataDAO) -> AnalysisResults:
+def run_image_analysis(video_data: VideoData) -> AnalysisResults:
     print("Running image analysis...")
     return AnalysisResults()

--- a/src/services/image_analysis_service.py
+++ b/src/services/image_analysis_service.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from src.classes.analysis_results import AnalysisResults
 from src.classes.video_data import VideoData
 

--- a/src/services/image_analysis_service_test.py
+++ b/src/services/image_analysis_service_test.py
@@ -20,12 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from src.classes.video_data import VideoData
+from src.classes.video_data import VideoDataDAO
 from src.services.image_analysis_service import run_image_analysis
 
 
 def test_run_image_analysis():
-    mock_video_data = VideoData(url="url@youtube.com", raw_video=[])
+    mock_video_data = VideoDataDAO(url="url@youtube.com", raw_video=[])
 
     results = run_image_analysis(mock_video_data)
 

--- a/src/services/image_analysis_service_test.py
+++ b/src/services/image_analysis_service_test.py
@@ -22,10 +22,11 @@
 
 from src.classes.video_data import VideoDataDAO
 from src.services.image_analysis_service import run_image_analysis
+from src.utils import default_variables as dv
 
 
 def test_run_image_analysis():
-    mock_video_data = VideoDataDAO(url="url@youtube.com", raw_video=[])
+    mock_video_data = VideoDataDAO(url=dv.video_url)
 
     results = run_image_analysis(mock_video_data)
 

--- a/src/services/image_analysis_service_test.py
+++ b/src/services/image_analysis_service_test.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from src.classes.video_data import VideoData
 from src.services.image_analysis_service import run_image_analysis
 

--- a/src/services/image_analysis_service_test.py
+++ b/src/services/image_analysis_service_test.py
@@ -20,13 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from src.classes.video_data import VideoDataDAO
+from src.classes.video_data import VideoData
 from src.services.image_analysis_service import run_image_analysis
 from src.utils import default_variables as dv
 
 
 def test_run_image_analysis():
-    mock_video_data = VideoDataDAO(url=dv.video_url)
+    mock_video_data = VideoData(url=dv.video_url)
 
     results = run_image_analysis(mock_video_data)
 

--- a/src/services/video_service.py
+++ b/src/services/video_service.py
@@ -20,9 +20,47 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from src.classes.video_data import VideoData
+import logging
+
+from src.classes.video_data import VideoDataDAO
+
+__author__ = ["Victor Calderon and Travis Craft"]
+__maintainer__ = ["Victor Calderon and Travis Craft"]
+__all__ = []
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger.setLevel(logging.INFO)
 
 
-def download_video(url: str) -> VideoData:
-    print(f"Downloading video from the following URL: {url}...")
-    return VideoData(url=url, raw_video=[])
+class VideoService(object):
+    """
+    Class object for the Video service.
+    """
+
+    def __init__(self, video_dao: "VideoDataDAO") -> None:
+        """
+        Class object for the Video Service.
+        """
+        self.video_dao = video_dao
+
+    def process_video(self):
+        """
+        Method for processing the input video.
+        """
+
+        return
+
+
+def download_video(url: str) -> VideoDataDAO:
+    """
+    Function to download a video object.
+    """
+    logger.info(f"Downloading video from the following URL: {url}...")
+    #
+    # Initializing object
+    video_obj = VideoDataDAO(url=url)
+    # Downloading video object
+    video_obj.download_stream()
+    #
+    return video_obj

--- a/src/services/video_service.py
+++ b/src/services/video_service.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from src.classes.video_data import VideoData
 
 

--- a/src/services/video_service.py
+++ b/src/services/video_service.py
@@ -22,7 +22,7 @@
 
 import logging
 
-from src.classes.video_data import VideoDataDAO
+from src.classes.video_data import VideoData
 
 __author__ = ["Victor Calderon and Travis Craft"]
 __maintainer__ = ["Victor Calderon and Travis Craft"]
@@ -38,7 +38,7 @@ class VideoService(object):
     Class object for the Video service.
     """
 
-    def __init__(self, video_dao: "VideoDataDAO") -> None:
+    def __init__(self, video_dao: "VideoData") -> None:
         """
         Class object for the Video Service.
         """
@@ -52,14 +52,14 @@ class VideoService(object):
         return
 
 
-def download_video(url: str) -> VideoDataDAO:
+def download_video(url: str) -> VideoData:
     """
     Function to download a video object.
     """
     logger.info(f"Downloading video from the following URL: {url}...")
     #
     # Initializing object
-    video_obj = VideoDataDAO(url=url)
+    video_obj = VideoData(url=url)
     # Downloading video object
     video_obj.download_stream()
     #

--- a/src/services/video_service_test.py
+++ b/src/services/video_service_test.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from src.services.video_service import download_video
 
 

--- a/src/services/video_service_test.py
+++ b/src/services/video_service_test.py
@@ -21,13 +21,13 @@
 # SOFTWARE.
 
 from src.services.video_service import download_video
+from src.utils import default_variables as dv
 
 
 def test_download_video():
-    mock_url = "url@youtube.com"
+    mock_url = dv.video_url
 
     downloaded_video = download_video(mock_url)
 
     assert downloaded_video is not None
     assert downloaded_video.url == mock_url
-    assert downloaded_video.raw_video == []

--- a/src/streamlit_app/__init__.py
+++ b/src/streamlit_app/__init__.py
@@ -1,0 +1,21 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/src/streamlit_app/app.py
+++ b/src/streamlit_app/app.py
@@ -20,10 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import absolute_import
+
 import contextlib
 import logging
 
 import streamlit as st
+
+from src.utils import default_variables as dv
 
 __author__ = ["Victor Calderon and Travis Craft"]
 __maintainer__ = ["Victor Calderon and Travis Craft"]
@@ -35,8 +39,6 @@ logger.setLevel(logging.INFO)
 
 # ------------------------- ENVIRONMENT VARIABLES -----------------------------
 
-APP_NAME = "Video and Image Analyzer"
-DEFAULT_CONFIDENCE_VALUE = 0.45
 
 # ------------------------------ MAIN FUNCTIONS -------------------------------
 
@@ -46,9 +48,9 @@ def main():
     Main function for the Streamlit Application
     """
     # --- Defining the layout
-    st.set_page_config(page_title=APP_NAME)
+    st.set_page_config(page_title=dv.project_app_name)
     # - Main page
-    st.title(APP_NAME)
+    st.title(dv.project_app_name)
     # - Sidebar of the application
     st.sidebar.title("Settings")
     # -- Model-specific configuration
@@ -58,7 +60,7 @@ def main():
         "Confidence level of the model",
         min_value=0.1,
         max_value=1.0,
-        value=DEFAULT_CONFIDENCE_VALUE,
+        value=dv.model_confidence_value,
     )
     # Type of device to use, i.e. CPU or GPU
     #

--- a/src/streamlit_app/app.py
+++ b/src/streamlit_app/app.py
@@ -1,0 +1,89 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import contextlib
+import logging
+
+import streamlit as st
+
+__author__ = ["Victor Calderon and Travis Craft"]
+__maintainer__ = ["Victor Calderon and Travis Craft"]
+__all__ = []
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger.setLevel(logging.INFO)
+
+# ------------------------- ENVIRONMENT VARIABLES -----------------------------
+
+APP_NAME = "Video and Image Analyzer"
+DEFAULT_CONFIDENCE_VALUE = 0.45
+
+# ------------------------------ MAIN FUNCTIONS -------------------------------
+
+
+def main():
+    """
+    Main function for the Streamlit Application
+    """
+    # --- Defining the layout
+    st.set_page_config(page_title=APP_NAME)
+    # - Main page
+    st.title(APP_NAME)
+    # - Sidebar of the application
+    st.sidebar.title("Settings")
+    # -- Model-specific configuration
+    st.sidebar.subheader("Model configuration")
+    # - Confidence level to use
+    confidence = st.sidebar.slider(
+        "Confidence level of the model",
+        min_value=0.1,
+        max_value=1.0,
+        value=DEFAULT_CONFIDENCE_VALUE,
+    )
+    # Type of device to use, i.e. CPU or GPU
+    #
+    st.sidebar.markdown("---")
+    # -- Media-specific
+    st.sidebar.subheader("Media configuration")
+    # Type of media to use, i.e. video or image
+    input_data_type = st.sidebar.radio(
+        "Select input type: ",
+        ["image", "video"],
+    )
+    # Input source, i.e. sample data, local, or on the web.
+    data_src = st.sidebar.radio(
+        "Select input source: ",
+        [
+            "Sample data",
+            "URL of the media",
+            "Upload your own data",
+        ],
+    )
+    logger.info(f"{data_src} | {input_data_type} | {confidence}")
+
+    return
+
+
+if __name__ == "__main__":
+    with contextlib.suppress(Exception):
+        main()

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,21 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/src/utils/default_variables.py
+++ b/src/utils/default_variables.py
@@ -1,0 +1,38 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# ----------------------------- GENERAL VARIABLES -----------------------------
+
+# Name of the project
+project_app_name = "Video and Image Analyzer"
+
+
+# ----------------------------- PROJECT VARIABLES -----------------------------
+
+# Level of confidence the model should have to report a result
+model_confidence_value = 0.45
+
+# Default URL of a Youtube video
+video_url = "https://youtu.be/MNn9qKG2UFI"
+
+# Default video format
+default_video_format = "mp4"

--- a/template.envrc
+++ b/template.envrc
@@ -6,3 +6,4 @@ export DOCKER_BUILDKIT_VALUE=1
 # --- Project variables
 export INPUT_APP_PORT=8090
 export OUTPUT_APP_PORT=80
+export STREAMLIT_SERVER_PORT=8501


### PR DESCRIPTION
## Description

This PR focuses on adding the infrastructure to use [Streamlit](https://streamlit.io/) as the application of the project, plus
some miscellaneous changes.

## Main changes

- Added the `default_variables` module, which includes the set of default values of various project variables.
- Added function to include the *license* header to all Python scripts. Also added these headers to the existing scripts.
- Streamlit-related
    - Updated the `Makefile` with functions to build, start, and stop the Streamlit service.
    - Added a temporary fix to the Dockerfile, which was preventing the use of  the`pytube` package.
- Added initial setup for the Video DAO.
- Updated the `template.envrc` with the streamlit-related environment variables.

## Related issues

- #17 
- #9 