### PR TITLE
Adding Pytube and OpenCV modules

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 79
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party =fastapi,pydantic,streamlit,validators
+known_third_party =fastapi,pydantic,pytube,streamlit,validators

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 79
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party =fastapi,pydantic,pytube,streamlit,validators
+known_third_party =cv2,fastapi,numpy,pydantic,pytube,streamlit,validators

--- a/docker/image_analyzer.Dockerfile
+++ b/docker/image_analyzer.Dockerfile
@@ -58,6 +58,10 @@ RUN apt-get -y update && \
     bash-completion \
     zsh \
     htop \
+    # Installing for Opencv
+    ffmpeg \
+    libsm6 \
+    libxext6 \
     && \
     # Cleaning out
     rm -rf /var/lib/apt/lists/* && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.92.0
+opencv-python==4.7.0.72
 pydantic==1.10.5
 pytube==12.1.2
 streamlit==1.20.0

--- a/src/classes/video_data.py
+++ b/src/classes/video_data.py
@@ -133,6 +133,6 @@ class VideoData(object):
         # Downloading video object
         return video_streams.first().download(
             output_path=output_path,
-            filename=output_basename,
+            filename=f"{output_basename}.{file_extension}",
             skip_existing=False,
         )

--- a/src/services/prep_service.py
+++ b/src/services/prep_service.py
@@ -1,0 +1,135 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import logging
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Optional
+
+import cv2
+import numpy as np
+
+from src.classes.video_data import VideoData
+from src.utils import default_variables as dv
+
+__author__ = ["Victor Calderon and Travis Craft"]
+__maintainer__ = ["Victor Calderon and Travis Craft"]
+__all__ = ["DataPreparationService"]
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logger.setLevel(logging.INFO)
+
+
+class DataPreparationService(object):
+    """
+    Main class object for the 'Data Preparation Service'.
+    """
+
+    def __init__(self, video_obj: "VideoData") -> None:
+        """
+        Class object for the 'Data Preparation Service'.
+
+        Parameters
+        -------------
+        video_obj : ``VideData``
+            Object for downloading the video.
+        """
+        # --- Initializing attributes
+        self.video_obj = video_obj
+
+    def show_params(self):
+        """
+        Method to show the attributes of the class.
+        """
+        msg = "-" * 50 + "\n"
+        msg += "\t---- INPUT PARAMETERS ----" + "\n"
+        msg += "" + "\n"
+        # Keys to omit
+        columns_to_omit = []
+        # Sorting keys of dictionary
+        keys_sorted = np.sort(list(self.__dict__.keys()))
+        for key_ii in keys_sorted:
+            if key_ii not in columns_to_omit:
+                msg += f"\t>>> {key_ii} : {self.__dict__[key_ii]}\n"
+        #
+        msg += "\n" + "-" * 50 + "\n"
+        logger.info(msg)
+
+    def extraction_of_video_frames(
+        self,
+        file_extension: Optional[str] = dv.default_video_extension,
+    ) -> Dict:
+        """
+        Method for extracting and storing the frames of the video.
+        """
+        # --- Download the video and extracting frames
+        # -- Video download
+        video_local_filepath = self.video_obj.download_stream(
+            file_extension=file_extension,
+        )
+        if not Path(video_local_filepath).exists():
+            msg = f">>> Filepath `{video_local_filepath}` does not exist!!"
+            logger.error(msg)
+            raise FileNotFoundError(msg)
+        # -- Extract frames
+        # - Open file and read in the frames
+        video_cv = cv2.VideoCapture(video_local_filepath)
+        # - Extracting video metadata
+        width = int(video_cv.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(video_cv.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        number_frames = int(video_cv.get(cv2.CAP_PROP_FRAME_COUNT))
+
+        logger.info(
+            f"Video -> width: {width} | height: {height} | N: {number_frames}"
+        )
+        # - Looping over each frame
+        video_frames_dict = defaultdict(dict)
+        frame_idx = 0
+        start_time = time.time()
+        while True:
+            # Extracting frame
+            ret, frame = video_cv.read()
+            if ret % 10 == 0:
+                logger.info(f"ret: {ret}")
+            if not ret or frame_idx == 500:
+                break
+            # Saving frame metadata to dictionary
+            video_frames_dict[frame_idx] = {"frame": frame}
+            # Increasing frame index
+            frame_idx += 1
+        #
+        end_time = time.time()
+        logger.info(f">> Took: {end_time - start_time}")
+        # Releasing video object
+        video_cv.release()
+
+        return video_frames_dict
+
+
+if __name__ == "__main__":
+    # Initializing video object
+    video_obj = VideoData(url=dv.video_url)
+    # Sending it to the Data Preparation object
+    data_prep_obj = DataPreparationService(video_obj=video_obj)
+    data_prep_obj.show_params()

--- a/src/services/prep_service.py
+++ b/src/services/prep_service.py
@@ -114,6 +114,8 @@ class DataPreparationService(object):
                 logger.info(f"ret: {ret}")
             if not ret or frame_idx == 500:
                 break
+            # Changing colors to RGB
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             # Saving frame metadata to dictionary
             video_frames_dict[frame_idx] = {"frame": frame}
             # Increasing frame index

--- a/src/utils/default_variables.py
+++ b/src/utils/default_variables.py
@@ -38,4 +38,4 @@ video_url = "https://youtu.be/MNn9qKG2UFI"
 target_item = "car"
 
 # Default video format
-default_video_format = "mp4"
+default_video_extension = "mp4"


### PR DESCRIPTION
## Description

This PR adds the methods for downloading videos from YouTube and extracting the frames from the source video.

## Main Changes

- OpenCV-realted
    - Updated Docker image to include missing packages needed for running `opencv`.
- Video-Data service
    -  Added method for downloading the video stream from Youtube after specifying the file extension needed.
- Prep Service
    - Added initial implementation of the *Data preparation service*.
    - Added method for reading in the video object and extracting the set of frames from it.
- Miscellaneous
    - Updated the default value for `default_video_extension` to `mp4`.

## Issues

- #8 
- #9 