### PR TITLE
Feature/17 flesh out streamlit

### DIFF
--- a/src/classes/analysis_results.py
+++ b/src/classes/analysis_results.py
@@ -26,5 +26,6 @@ from pydantic import BaseModel
 
 
 class AnalysisResults(BaseModel):
-    image: Any
-    inference: Any
+    output_image: Any
+    fps: float
+    inference_results: Any

--- a/src/classes/analysis_results.py
+++ b/src/classes/analysis_results.py
@@ -20,8 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import Any
+
 from pydantic import BaseModel
 
 
 class AnalysisResults(BaseModel):
-    pass
+    image: Any
+    inference: Any

--- a/src/services/image_analysis_service.py
+++ b/src/services/image_analysis_service.py
@@ -28,4 +28,4 @@ from src.classes.video_data import VideoData
 
 def run_image_analysis(video_data: VideoData) -> List[AnalysisResults]:
     print("Running image analysis...")
-    return [AnalysisResults()]
+    return [AnalysisResults(output_image={}, fps=60, inference_results={})]

--- a/src/services/image_analysis_service.py
+++ b/src/services/image_analysis_service.py
@@ -20,10 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import List
+
 from src.classes.analysis_results import AnalysisResults
 from src.classes.video_data import VideoData
 
 
-def run_image_analysis(video_data: VideoData) -> AnalysisResults:
+def run_image_analysis(video_data: VideoData) -> List[AnalysisResults]:
     print("Running image analysis...")
-    return AnalysisResults()
+    return [AnalysisResults()]

--- a/src/services/image_analysis_service.py
+++ b/src/services/image_analysis_service.py
@@ -27,5 +27,21 @@ from src.classes.video_data import VideoData
 
 
 def run_image_analysis(video_data: VideoData) -> List[AnalysisResults]:
+    """
+    Method for analyzing video data using a modeling service.
+
+    Parameters
+    --------------
+    video_data : VideoData
+        Video data to be analyzed.
+
+    Returns
+    ------------
+    analysis_results : List[AnalysisResults]
+        List of AnalysisResults objects for each frame.
+        This includes the processed image and inference results
+        from the modeling service.
+
+    """
     print("Running image analysis...")
     return [AnalysisResults(output_image={}, fps=60, inference_results={})]

--- a/src/streamlit_app/app.py
+++ b/src/streamlit_app/app.py
@@ -136,7 +136,7 @@ def handle_analysis(url: str):
     results = run_image_analysis(video_data)
     for frame in results:
         logger.info("Frame results: ", frame)
-        output.image(frame.output_img)
+        output.image(frame.output_image)
         fps = frame.fps
         st1_text.markdown(f"**{height}**")
         st2_text.markdown(f"**{width}**")

--- a/src/utils/steamlit_enums.py
+++ b/src/utils/steamlit_enums.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 Victor Calderon and Travis Craft
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from enum import Enum
 
 

--- a/src/utils/steamlit_enums.py
+++ b/src/utils/steamlit_enums.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class MediaSource(str, Enum):
+    SAMPLE_DATA = "Sample data"
+    URL = "URL of the media"
+
+    def __str__(self) -> str:
+        return str.__str__(self)
+
+
+class MediaType(str, Enum):
+    IMAGE = "Image"
+    VIDEO = "Video"
+
+    def __str__(self) -> str:
+        return str.__str__(self)


### PR DESCRIPTION
This is an incremental PR for the Streamlit web app. I've updated the Streamlit app to accept a user defined URL and moved some code around into separate methods. Once we get the modeling code in place we can circle back to update the Streamlit UI to accept a target item and display the modeling results.

Key Changes:

- Added enums for media types to clean up hard coded strings
- Separated Streamlit workflow into three methods
   - Building the initial page
   - Gathering the URL
   - Running the analysis
 - I updated some placeholder analysis code which we will swap out once the modeling flow is in place
    - `AnalysisResults`
    - `run_image_analysis`
    - Used the `Any` type temporarily

## Issue

- #17 